### PR TITLE
upgrade version that shows in Ember inspector info tab

### DIFF
--- a/vendor/ember-simple-auth/register-version.js
+++ b/vendor/ember-simple-auth/register-version.js
@@ -1,1 +1,1 @@
-Ember.libraries.register('Ember Simple Auth', '1.1.0');
+Ember.libraries.register('Ember Simple Auth', '1.2.0-beta.1');


### PR DESCRIPTION
This was likely missed when creating 1.2.0-beta.1 release.